### PR TITLE
update migration for postgres support

### DIFF
--- a/migrations/m161118_101349_alter_charset_to_utf8.php
+++ b/migrations/m161118_101349_alter_charset_to_utf8.php
@@ -6,7 +6,9 @@ class m161118_101349_alter_charset_to_utf8 extends Migration
 {
     public function up()
     {
-        Yii::$app->db->createCommand("ALTER TABLE dmstr_page CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci ;")->execute();
+        if ($this->db->driverName !== 'pgsql') {
+            Yii::$app->db->createCommand("ALTER TABLE dmstr_page CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci ;")->execute();
+        }
     }
 
     public function down()


### PR DESCRIPTION
This is not valid syntax for Potgresql. I didn't find a way to adopt it for Postgres.  As I understand correctly it's not possible to have one table's charset differ from whole DB charset. So it makes no sense to have such migration for Postgres. Correct me if I'm wrong or accept please. 