### PR TITLE
fixes pages asset dependencies

### DIFF
--- a/assets/PagesAsset.php
+++ b/assets/PagesAsset.php
@@ -19,6 +19,6 @@ class PagesAsset extends AssetBundle
         'module.less',
     ];
     public $depends = [
-        'rmrevin\yii\fontawesome\AssetBundle',
+        '\dmstr\web\AdminLteAsset'
     ];
 }


### PR DESCRIPTION
we use `insolita\wgadminlte\Box`and other from `dmstr\web\AdminLteAsset` in pages treeview form. If we do not use this dependency in the `PagesAsset`, rendering the pages module in an other layout than our `dmstr/yii2-backend-module` it doesnt feel and work properly.

@schmunk42 could you please tag a 0.21.9 ?