### PR TITLE
check access_read in default:page action

### DIFF
--- a/controllers/DefaultController.php
+++ b/controllers/DefaultController.php
@@ -109,6 +109,13 @@ JS;
         // get page
         $page = $pageQuery->one();
 
+        // check if page has access_read permissions set, if yes check if user is allowed
+        if ((!empty($page->access_read) && ($page->access_read != '*'))) {
+            if (!\Yii::$app->user->can($page->access_read)) {
+                throw new HttpException(403, \Yii::t('pages', 'Forbidden'));
+            }
+        }
+
         if ($page !== null) {
             // Set page title, use name as fallback
             $this->view->title = $page->page_title ?: $page->name;


### PR DESCRIPTION
Currently if the pages_default_page permission is granted for  the 'Unauthenticated User' role, all (visible and not disabled) pages are public.

I've added a simple access_read check  in the default::page action, so we can create e.g. pages which are only accessible for users with backend GRANTs.

Any objections?