### PR TITLE
changed access_read check in Default::actionPage()

### DIFF
--- a/controllers/DefaultController.php
+++ b/controllers/DefaultController.php
@@ -12,7 +12,6 @@ namespace dmstr\modules\pages\controllers;
 use dmstr\modules\pages\assets\PagesAsset;
 use dmstr\modules\pages\models\Tree;
 use yii\helpers\Url;
-use yii\helpers\VarDumper;
 use yii\web\Controller;
 use yii\web\HttpException;
 use yii\web\View;

--- a/controllers/DefaultController.php
+++ b/controllers/DefaultController.php
@@ -119,8 +119,6 @@ JS;
                 if (!\Yii::$app->user->isGuest) {
                     throw new HttpException(403, \Yii::t('pages', 'Forbidden'));
                 } else {
-                    #echo "forbidden -> login" ; exit;
-                    #VarDumper::dump(\Yii::$app->user, 10, 1);
                     return $this->redirect(\Yii::$app->user->loginUrl,302);
                 }
             }

--- a/controllers/DefaultController.php
+++ b/controllers/DefaultController.php
@@ -109,6 +109,13 @@ JS;
         // get page
         $page = $pageQuery->one();
 
+        // check if page has access_read permissions set, if yes check if user is allowed
+        if ((!empty($page->access_read) && ($page->access_read != '*'))) {
+            if (!\Yii::$app->user->can($page->access_read)) {
+                throw new HttpException(403, \Yii::t('pages', 'Forbidden'));
+            }
+        }
+
         if ($page !== null) {
             // Set page title, use name as fallback
             $this->view->title = $page->page_title ?: $page->name;


### PR DESCRIPTION
With Tree::$activeAccessTrait = true pages with access_read != '*' would only generate 404 pages for GuestUser and Users without appropriate GRANTs, because the access check will be made in model::find Method.

This patch deactivate Tree::$activeAccessTrait in actionPage, so access_* checks wouldn't be added to Query in ActiveRecordAccessTrait::find() anymore.

Then we can handle these checks here, redirect Guest users to login URL or send correct 403 Status for logged in Users without appropriate GRANTs.

Related:  https://github.com/dmstr/yii2-db/pull/17

