### PR TITLE
Optionally delete invisible or disabled nodes recursively

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -69,6 +69,27 @@ class Module extends \yii\base\Module
     public $pageUseFallbackPage = true;
 
     /**
+     * Whether Tree::getMenuItems() should remove all childs for all invisible nodes from menu tree
+     *
+     * @var bool
+     */
+    public $menuRemoveInvisibleRecursive = false;
+
+    /**
+     * Whether Tree::getMenuItems() should return an empty array for invisible root nodes
+     *
+     * @var bool
+     */
+    public $menuRemoveInvisibleRoot = false;
+
+    /**
+     *  Whether Tree::getMenuItems() should remove all childs for all disabled nodes from menu tree
+     *
+     * @var bool
+     */
+    public $menuRemoveDisabledRecursive = false;
+
+    /**
      * @inheritdoc
      */
     public function init()


### PR DESCRIPTION
Currently, visible and disabled flags of a node are not noticed for its children in `Tree::getMenuItems()`.

Therefore it is currently not possible to "hide" a whole part of a tree from the menu by deactivating the visible flag of a parent node.  The parent node itself will disappear from the menu, but its children will still be visible.

This behavior can also lead to strange effects, because children can lose their parent in the tree and appear at an unexpected position in the menu tree.

This PR implements the recursive deletion of a whole subtree from the menu using the visible or disable flag of a parent node in the tree.

The behaviour can be controlled by 3 new module properties:

- `$menuRemoveInvisibleRecursive`: Whether Tree::getMenuItems() should remove all childs for all invisible nodes from menu tree
- `$menuRemoveDisabledRecursive`: Whether Tree::getMenuItems() should remove all childs for all disabled nodes from menu tree
- `$menuRemoveInvisibleRoot`: Whether Tree::getMenuItems() should return an empty array for invisible root nodes

All 3 properties are set to `false` by default for backward compatibility.