### PR TITLE
Feature/action ref page

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -76,7 +76,7 @@ class Module extends \yii\base\Module
         parent::init();
 
         // add routes from settings module
-        if ($this->checkSettingsInstalled()) {
+        if (self::checkSettingsInstalled()) {
             $routes = explode("\n", \Yii::$app->settings->get('pages.availableRoutes'));
             foreach ($routes as $route) {
                 $routeEntry = trim($route);
@@ -130,7 +130,7 @@ class Module extends \yii\base\Module
      * Check for "pheme/yii2-settings" component and module
      * @return bool
      */
-    private function checkSettingsInstalled()
+    public static function checkSettingsInstalled()
     {
         return \Yii::$app->hasModule('settings') && \Yii::$app->has('settings');
     }

--- a/controllers/DefaultController.php
+++ b/controllers/DefaultController.php
@@ -124,7 +124,7 @@ JS;
     public function actionPage($pageId)
     {
         Url::remember();
-        \Yii::$app->session['__crudReturnUrl'] = null;
+        \Yii::$app->session->set('__crudReturnUrl', null);
 
         // Set layout
         $this->layout = $this->module->defaultPageLayout;

--- a/traits/RequestParamActionTrait.php
+++ b/traits/RequestParamActionTrait.php
@@ -207,7 +207,7 @@ JSON;
             } else {
 
                 // add defaults here again to guarantee same behavior as if property would have a corresponding method
-                $extraProperties = '"type": "string","title": "' . Inflector::camel2words($parameterName) . '"';
+                $extraProperties = ['"type": "string"','"title": "' . Inflector::camel2words($parameterName) . '"'];
 
                 if (!$parameter->isOptional()) {
                     $requiredFields[] = $parameterName;
@@ -215,6 +215,7 @@ JSON;
                 }
 
                 // generate default if nothing else is defined
+                $extraProperties = implode(',', $extraProperties);
                 $properties[] = $this->defaultFieldJson($parameterName, $extraProperties);
             }
         }


### PR DESCRIPTION
This PR add a new pages action `refPage`

**Usecase**:
- someone wants to reference an existing `/pages/default/page` at an arbitrary location within the page trees.
- Currently you would have to create another page/default/page and then overload the req-param pageId for this one manually".
- The new page would then render the content of the existing page, but in addition to the unwieldy maintenance (pageId overload), this would also create a duplicate content problem.

**Solution:**
- the new `/pages/default/ref-page` route can be used to reference any existing pages via their `pageId`
- the refPage action checks if given pageId exists, if yes redirect to the target page (to prevent duplicate content), if no return a 404
- in the backend the available pages which can be referenced are provided via `RequestParamActionTrait` as select with human readable labels, so you don't have to set the ID manually.
- the RootIds (DomainIds for root nodes) from which the available pages are offered as targets can be defined via the optional setting `pages.refPageRootIds`. Default is `Tree::ROOT_NODE_PREFIX` 

