### PR TITLE
refactored RequestParamActionTrait

### DIFF
--- a/traits/RequestParamActionTrait.php
+++ b/traits/RequestParamActionTrait.php
@@ -163,14 +163,17 @@ trait RequestParamActionTrait
                     }
                 }
 
+                // assign additionalData from docBlock in paramStruct
                 foreach ($additionalData as $name => $value) {
                     // if value looks like json object or array, get struct from json string
-                    if ((substr($value, 0, 1) === '[' && substr($value, -1) !== ']') || (substr($value, 0, 2) === '{"'  && substr($value, -1, 2) === '"}') ) {
+                    $value = trim($value);
+                    if ( preg_match('#^(\{.+\})|(\[.+\])$#', $value)) {
                         $value = json_decode($value);
                     }
                     $paramStruct->$name = $value;
                 }
 
+                // set enum options
                 if (\is_array($enumData)) {
                     // if we want string, cast keys to string, otherwise we would get IDs as int
                     if ($paramStruct->type === 'string') {
@@ -181,15 +184,15 @@ trait RequestParamActionTrait
 
                     // ensure options is set...
                     if (!isset($paramStruct->options)) {
-                        $paramStruct->options = [];
+                        $paramStruct->options = new \stdClass();
                     }
                     // ... and add enum_titles, ensure strings
-                    $paramStruct->options['enum_titles'] = array_map('strval', array_values($enumData));
+                    $paramStruct->options->enum_titles = array_map('strval', array_values($enumData));
                 }
 
             }
 
-            // add to required if param is not optional
+            // add to required list if param is not optional
             if (!$parameter->isOptional()) {
                 $requiredFields[] = $parameterName;
                 // TODO: how to check other types?

--- a/traits/RequestParamActionTrait.php
+++ b/traits/RequestParamActionTrait.php
@@ -21,13 +21,13 @@ use yii\helpers\Inflector;
 /**
  * This trait will enable auto fetching request params to append matching JSON for request param's json editor
  *
- * USUAGE / HOW IT WORKS:
+ * USAGE / HOW IT WORKS:
  *
  * To enable for a specific controller, use this trait in the desired controller
  *
- * By default it will generate a text field per action parameter.
+ * By default, it will generate a text field per action parameter.
  *
- * For customization you can create a public method for each individual action parameter by adding a method which name
+ * For customization, you can create a public method for each individual action parameter by adding a method which name
  * have to follow this schema:
  *
  * `camelizedActionId` + ActionParam + `ParameterName`
@@ -37,7 +37,7 @@ use yii\helpers\Inflector;
  *
  * Example: detailActionParamProductId
  *
- * This method must return a array (key-value pairs), where the keys should refer to the actual value and the value will
+ * This method must return an array (key-value pairs), where the keys should refer to the actual value and the value will
  * be the label
  *
  * Example:
@@ -63,7 +63,7 @@ use yii\helpers\Inflector;
  *     return true;
  *   }
  *
- *   This will generate a input with defined title for an *existing* parameter
+ *   This will generate an input with defined title for an *existing* parameter
  *
  * - If property is NOT optional, it will be set as required in json schema.
  *   However, since this only implies that the property must be set in the data, but not that a value must also be set,

--- a/traits/RequestParamActionTrait.php
+++ b/traits/RequestParamActionTrait.php
@@ -15,6 +15,7 @@ use ReflectionClass;
 use ReflectionException;
 use ReflectionMethod;
 use ReflectionParameter;
+use Yii;
 use yii\helpers\Inflector;
 
 /**
@@ -118,7 +119,7 @@ trait RequestParamActionTrait
 
         // init main json struct object with defaults
         $jsonStruct = new \stdClass();
-        $jsonStruct->title = 'Request Params';
+        $jsonStruct->title = Yii::t('pages', 'Request Params');
         $jsonStruct->type = "object";
         $jsonStruct->properties = [];
 


### PR DESCRIPTION
So far the json schema was assembled "by hand" as a string in RequestParamActionTrait.

This had the problem that e.g. control characters like \u0009 were not escaped correctly as json strings.

In this PR RequestParamActionTrait was refactored so that the json schema is now build as php data struct and than encoded as json using the default php json_encode() func
