### PR TITLE
allow varchar 255 for access_owner as in other access_ cols

### DIFF
--- a/migrations/m230606_120121_change_access_owner_col_format.php
+++ b/migrations/m230606_120121_change_access_owner_col_format.php
@@ -1,0 +1,17 @@
+<?php
+
+use yii\db\Migration;
+
+class m230606_120121_change_access_owner_col_format extends Migration
+{
+    public function up()
+    {
+        // allow uuid and longer strings as access_owner value
+        $this->alterColumn("{{%dmstr_page}}", "access_owner", $this->string(255));
+    }
+
+    public function down()
+    {
+        return false;
+    }
+}

--- a/models/BaseTree.php
+++ b/models/BaseTree.php
@@ -459,6 +459,13 @@ class BaseTree extends \kartik\tree\models\Tree
                 ],
                 [
                     [
+                        self::ATTR_ACCESS_OWNER,
+                    ],
+                    'filter',
+                    'filter' => 'strval'
+                ],
+                [
+                    [
                         self::ATTR_DOMAIN_ID,
                         self::ATTR_PAGE_TITLE,
                         self::ATTR_SLUG,
@@ -467,6 +474,7 @@ class BaseTree extends \kartik\tree\models\Tree
                         self::ATTR_ICON,
                         self::ATTR_DEFAULT_META_KEYWORDS,
                         self::ATTR_REQUEST_PARAMS,
+                        self::ATTR_ACCESS_OWNER,
                         self::ATTR_ACCESS_READ,
                         self::ATTR_ACCESS_UPDATE,
                         self::ATTR_ACCESS_DELETE,
@@ -522,7 +530,6 @@ class BaseTree extends \kartik\tree\models\Tree
                 [
                     [
                         self::ATTR_ROOT,
-                        self::ATTR_ACCESS_OWNER,
                     ],
                     'integer',
                     'integerOnly' => true,
@@ -530,7 +537,6 @@ class BaseTree extends \kartik\tree\models\Tree
                 [
                     [
                         self::ATTR_ROOT,
-                        self::ATTR_ACCESS_OWNER,
                         self::ATTR_COLLAPSED,
                         self::ATTR_ICON_TYPE
                     ],

--- a/models/Tree.php
+++ b/models/Tree.php
@@ -38,7 +38,7 @@ use JsonSchema\Validator;
  * @property string $default_meta_keywords
  * @property string $default_meta_description
  * @property string $request_params
- * @property int $access_owner
+ * @property string $access_owner
  * @property string $access_domain
  * @property string $access_read
  * @property string $access_update


### PR DESCRIPTION
Ths PR changes the access_owner attribute type from int(11) to string(255) to be able to store e.g. uuids