### PR TITLE
Removed unnecessary namespaces from unit tests

### DIFF
--- a/tests/codeception/unit/ModelTest.php
+++ b/tests/codeception/unit/ModelTest.php
@@ -1,8 +1,6 @@
 <?php
 // @group mandatory
 
-namespace dmstr\modules\pages\tests\unit;
-
 use dmstr\modules\pages\models\Tree;
 
 class ModelTestCase extends \Codeception\Test\Unit

--- a/tests/codeception/unit/UrlTest.php
+++ b/tests/codeception/unit/UrlTest.php
@@ -1,8 +1,6 @@
 <?php
 // @group mandatory
 
-namespace dmstr\modules\pages\tests\unit;
-
 use Codeception\Util\Debug;
 use dmstr\modules\pages\components\PageUrlRule;
 use dmstr\modules\pages\models\Tree;


### PR DESCRIPTION
Solution to fix an error message that appears when any composer command is running

<img width="1375" alt="composer-output" src="https://github.com/dmstr/yii2-pages-module/assets/13000805/05a87e84-aded-4921-905e-6faf8790ac84">

The namespace is optional at this point so the easy solution was to remove it like in any other codeception cest in this package
