### PR TITLE
Fixed migration

### DIFF
--- a/migrations/m180321_103245_alter_table_names.php
+++ b/migrations/m180321_103245_alter_table_names.php
@@ -13,8 +13,10 @@ class m180321_103245_alter_table_names extends Migration
     public function safeUp()
     {
 
-        $this->renameTable('dmstr_page','{{%dmstr_page}}');
-        $this->renameTable('dmstr_page_translation','{{%dmstr_page_translation}}');
+        if (!empty($this->getDb()->tablePrefix)) {
+            $this->renameTable('dmstr_page','{{%dmstr_page}}');
+            $this->renameTable('dmstr_page_translation','{{%dmstr_page_translation}}');
+        }
 
     }
 


### PR DESCRIPTION
Kind of an edge case but if table prefix of the given db connection is empty an error could occur on migrate/up

Tested with empty envs and postgres db