### PR TITLE
DefaultController::actionPage param checks

### DIFF
--- a/controllers/DefaultController.php
+++ b/controllers/DefaultController.php
@@ -272,6 +272,9 @@ JS;
             }
 
             // Render view
+            if (empty($page->view)) {
+                throw new HttpException(404, \Yii::t('pages', 'Page not found.') . ' [ID: ' . $pageId . ']');
+            }
             return $this->render($page->view, ['page' => $page]);
         } else {
             if ($fallbackPage = $this->resolveFallbackPage($pageId)) {

--- a/controllers/DefaultController.php
+++ b/controllers/DefaultController.php
@@ -244,6 +244,15 @@ JS;
             $page = null;
         }
 
+        // if the route of the $page does not point to $this->route, make a redirect to the destination url
+        if ($page !== null && ltrim('/', $page->route) !== $this->route) {
+            $destRoute = [$page->route];
+            if (!empty($page->request_params) && Json::decode($page->request_params)) {
+                $destRoute = ArrayHelper::merge($destRoute, Json::decode($page->request_params));
+            }
+            return $this->redirect($destRoute);
+        }
+
         # reactivate access_* check in ActiveRecordAccessTrait::find for further queries
         Tree::$activeAccessTrait = true;
         // check if page has access_read permissions set, if yes check if user is allowed


### PR DESCRIPTION
This PR handle/fix 2 problems:

**1. route not checked correctly**
if a tree node exists with e.g. id 100 and the route of the tree node is not `pages/default/page`, the "page" under the `pages/default/page` route is still accessible. It will be shown as a blank page, or with a server error, but in any case in an undefined state.

This PR checks the route param of the found tree model, compare it with the route of the controller/action itself and if this does not match, makes a redirect to the route of the tree model.

**2. $page->view param is not checked before render**
If the tree node `$page`, for whatever reason, has no view defined, i.e. $page->view is empty, the render(/) method is called anyway, which leads to an internal server error. 

The PR now checks this at least rudimentarily and if $page->view is empty, a 404 is generated.