### PR TITLE
An return to redirect response for ref-page action

### DIFF
--- a/controllers/DefaultController.php
+++ b/controllers/DefaultController.php
@@ -196,7 +196,7 @@ JS;
 
         $page = Tree::findOne(['id' => $pageId]);
         if ($page && $page instanceof Tree) {
-            $this->redirect($page->createUrl());
+            return $this->redirect($page->createUrl());
         } else {
             throw new NotFoundHttpException();
         }


### PR DESCRIPTION
It is always a good idea to return a redirect response as this will directly return the response in the applications request handler.