### PR TITLE
RequestParamActionTrait::jsonFromAction - use default action for contgroller only routes

### DIFF
--- a/traits/RequestParamActionTrait.php
+++ b/traits/RequestParamActionTrait.php
@@ -92,8 +92,14 @@ trait RequestParamActionTrait
     public function jsonFromAction($route)
     {
         try {
-            // get action id from route
-            $actionId = lcfirst(Inflector::camelize(basename($route)));
+            // catch routes without named action
+            // and use the controller default action as fallback
+            if ($this->getUniqueId() === trim($route, '/')) {
+                $actionId = lcfirst($this->defaultAction);
+            } else {
+                // in all other cases get action id from route
+                $actionId = lcfirst(Inflector::camelize(basename($route)));
+            }
 
             // get potential action name in controller
             $actionName = 'action' . Inflector::camelize($actionId);


### PR DESCRIPTION
Currently RequestParamActionTrait::jsonFromAction can only handle full action routes as it use `basename($route)` to get the `actionId` before searching for callback methods.

Examples
- `/frontend/product/index` will set `actionId` to `index` and search for `indexActionParamSchema()` in the product controller
- `/frontend/product` will set `actionId` to `product` search for `productActionParamSchema()` in the product controller

This PR enhances the `actionId` initialization by first checking whether the passed route match the `controller::getUniqueId()`. If so, `controller::defaultAction` is used as `actionId`.