### PR TITLE
fix permission errors

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -18,7 +18,6 @@ use yii\console\Application;
  *
  * @author Christopher Stebe <c.stebe@herzogkommunikation.de>
  *
- * @property mixed|object $localizedRootNode
  */
 class Module extends \yii\base\Module
 {

--- a/Module.php
+++ b/Module.php
@@ -108,25 +108,6 @@ class Module extends \yii\base\Module
     }
 
     /**
-     * @return mixed|object dmstr\modules\pages\models\Tree
-     */
-    public function getLocalizedRootNode()
-    {
-        $localizedRoot = Tree::ROOT_NODE_PREFIX.'_'.\Yii::$app->language;
-        \Yii::trace('localizedRoot: '.$localizedRoot, __METHOD__);
-        $rootNode = Tree::findOne(
-            [
-                Tree::ATTR_DOMAIN_ID => Tree::ROOT_NODE_PREFIX,
-                Tree::ATTR_ACTIVE => Tree::ACTIVE,
-            ]
-        );
-        if ($rootNode !== null && !$rootNode->isVisible()) {
-            return null;
-        }
-        return $rootNode;
-    }
-
-    /**
      * Check for "pheme/yii2-settings" component and module
      * @return bool
      */

--- a/README.md
+++ b/README.md
@@ -216,11 +216,14 @@ Run tests
     make run-tests
     
 
-Ressources
+Changelog
 ----------
 
-tbd
+2.5.10
 
----
+- Removed localized root node message
+- Updated kartik-v/yii2-tree-manager requirement to ^1.1.2
+- Update Tree model to support new child_allowed attribute (since kartik-v/yii2-tree-manager 1.0.9)
+- Improved permission check for page nodes so allowed child nodes in not allowed parents do not show up
 
 ### ![dmstr logo](http://t.phundament.com/dmstr-16-cropped.png) Built by [dmstr](http://diemeisterei.de)

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "yiisoft/yii2": "*",
-        "kartik-v/yii2-tree-manager": ">=1.0.3 <=1.0.5",
+        "kartik-v/yii2-tree-manager": "^1.1.2",
         "kartik-v/yii2-widget-select2": "^2.0.1",
         "2amigos/yii2-translateable-behavior": "^1.1.0",
         "insolita/yii2-adminlte-widgets": "^1.1.4",

--- a/controllers/DefaultController.php
+++ b/controllers/DefaultController.php
@@ -121,7 +121,7 @@ class DefaultController extends Controller implements ContextMenuItemsInterface
     public function actionIndex($pageId = null)
     {
         $query = Tree::getAccessibleItemsQuery();
-        
+
         $headerTemplate = <<< HTML
 <div class="row">
     <div class="col-sm-6" id="dmstr-pages-detail-heading">
@@ -183,7 +183,8 @@ HTML;
             'query' => $query,
             'headerTemplate' => $headerTemplate,
             'toolbar' => $toolbar,
-            'mainTemplate' => $mainTemplate
+            'mainTemplate' => $mainTemplate,
+            'pageId' => $pageId
         ]);
     }
 

--- a/controllers/DefaultController.php
+++ b/controllers/DefaultController.php
@@ -118,34 +118,6 @@ class DefaultController extends Controller implements ContextMenuItemsInterface
      */
     public function actionIndex($pageId = null)
     {
-        $localicedRootNode = $this->module->getLocalizedRootNode();
-        if (!$localicedRootNode) {
-            $language = mb_strtolower(\Yii::$app->language);
-            $rootNodePrefix = Tree::ROOT_NODE_PREFIX;
-
-            $msg = <<<HTML
-<b>Localized root-node missing</b>
-<p>
-Please create a new root-node for the current language.
-</p>
-<p>
-<a onclick="$('#tree-domain_id').val('{$rootNodePrefix}');$('#tree-name').val('{$rootNodePrefix}_{$language}');$('.kv-detail-container button[type=submit]').click()" 
-   class="btn btn-warning">Create root-node for <b>{$language}</b></a>
-</p>
-HTML;
-
-            $js = <<<'JS'
-$(".kv-create-root").click();
-JS;
-
-            $this->getView()->registerJs($js, View::POS_LOAD);
-            \Yii::$app->session->addFlash('warning', $msg);
-        } else {
-            if (!empty($pageId)) {
-                Yii::$app->session->set('kvNodeId', $pageId);
-            }
-        }
-
         /**
          * Register the pages asset bundle
          */

--- a/controllers/DefaultController.php
+++ b/controllers/DefaultController.php
@@ -120,17 +120,8 @@ class DefaultController extends Controller implements ContextMenuItemsInterface
      */
     public function actionIndex($pageId = null)
     {
-        $query = Tree::find()
-            ->andWhere(
-                [
-                    Tree::ATTR_ACCESS_DOMAIN => [
-                        Yii::$app->language,
-                        Tree::GLOBAL_ACCESS_DOMAIN
-                    ]
-                ]
-            )
-            ->orderBy('root, lft');
-
+        $query = Tree::getAccessibleItemsQuery();
+        
         $headerTemplate = <<< HTML
 <div class="row">
     <div class="col-sm-6" id="dmstr-pages-detail-heading">

--- a/controllers/DefaultController.php
+++ b/controllers/DefaultController.php
@@ -120,6 +120,12 @@ class DefaultController extends Controller implements ContextMenuItemsInterface
      */
     public function actionIndex($pageId = null)
     {
+
+        // do rbac permission check if page is readable. The active record permssion check does not show the page if it does not exist
+        if (!empty($pageId) && empty(Tree::findOne($pageId))) {
+            throw new NotFoundHttpException(Yii::t('pages', 'The requested page does not exist.'));
+        }
+
         $query = Tree::getAccessibleItemsQuery();
 
         $headerTemplate = <<< HTML

--- a/controllers/DefaultController.php
+++ b/controllers/DefaultController.php
@@ -120,7 +120,7 @@ class DefaultController extends Controller implements ContextMenuItemsInterface
      */
     public function actionIndex($pageId = null)
     {
-        $queryTree = Tree::find()
+        $query = Tree::find()
             ->andWhere(
                 [
                     Tree::ATTR_ACCESS_DOMAIN => [
@@ -189,7 +189,7 @@ HTML;
         $this->view->title = Yii::t('pages', 'Pages');
 
         return $this->render('index', [
-            'queryTree' => $queryTree,
+            'query' => $query,
             'headerTemplate' => $headerTemplate,
             'toolbar' => $toolbar,
             'mainTemplate' => $mainTemplate

--- a/models/BaseTree.php
+++ b/models/BaseTree.php
@@ -30,6 +30,10 @@ class BaseTree extends \kartik\tree\models\Tree
 {
     use ActiveRecordAccessTrait;
 
+    // needed since 1.0.9. Currently we want all children to have children so new need for a extra db field (yet)
+    // If that changes in the future, the default value must be `1` to ensure backwards compatibility
+    public $child_allowed = 1;
+
     /**
      * Icon type css
      */

--- a/models/Tree.php
+++ b/models/Tree.php
@@ -362,7 +362,7 @@ class Tree extends BaseTree
                 ['<', 'parent.lft', new Expression($tableName . '.lft')],
                 ['>', 'parent.rgt', new Expression($tableName . '.rgt')],
                 ['=', 'parent.root', new Expression($tableName . '.root')],
-                ['>', 'parent.lvl', 0], // Exclude root nodes from parent check
+                ['>=', 'parent.lvl', 0], // Include root nodes in parent check
                 [Tree::ATTR_ACCESS_DOMAIN => [Yii::$app->language, Tree::GLOBAL_ACCESS_DOMAIN]]
             ])
             ->andWhere(['NOT', $directAccessCondition]); // Parents that DON'T have access

--- a/views/default/index.php
+++ b/views/default/index.php
@@ -7,6 +7,7 @@
  * @var string $headerTemplate
  * @var string $mainTemplate
  * @var array $toolbar
+ * @var int|string $pageId
  */
 use dmstr\modules\pages\models\Tree;
 use kartik\tree\TreeView;
@@ -17,7 +18,7 @@ echo TreeView::widget(
         'query' => $query,
         'isAdmin' => true,
         'softDelete' => false,
-        'displayValue' => 1,
+        'displayValue' => $pageId,
         'showTooltips' => false,
         'wrapperTemplate' => '{header}{footer}{tree}',
         'headingOptions' => ['label' => Yii::t('pages', 'Nodes')],

--- a/views/default/index.php
+++ b/views/default/index.php
@@ -20,7 +20,7 @@ echo TreeView::widget(
         'displayValue' => 1,
         'showTooltips' => false,
         'wrapperTemplate' => '{header}{footer}{tree}',
-        'headingOptions' => ['label' => 'Nodes'],
+        'headingOptions' => ['label' => Yii::t('pages', 'Nodes')],
         'treeOptions' => ['style' => 'height:auto; min-height:400px'],
         'headerTemplate' => $headerTemplate,
         'mainTemplate' => $mainTemplate,

--- a/views/default/index.php
+++ b/views/default/index.php
@@ -2,80 +2,16 @@
 /**
  * Output TreeView widget
  *
- * @var $this yii\web\View
- * @var $queryTree \yii\db\ActiveQuery
+ * @var yii\web\View $this
+ * @var \yii\db\ActiveQuery $queryTree
+ * @var string $headerTemplate
+ * @var string $mainTemplate
+ * @var array $toolbar
  */
 use dmstr\modules\pages\models\Tree;
 use kartik\tree\TreeView;
 use yii\helpers\Inflector;
 
-$this->title = Inflector::titleize($this->context->module->id);
-
-/**
- * Wrapper templates
- */
-$headerTemplate = <<< HTML
-<div class="row">
-    <div class="col-sm-6" id="dmstr-pages-detail-heading">
-        {heading}
-    </div>
-    <div class="col-sm-6" id="dmstr-pages-detail-search">
-        {search}
-    </div>
-</div>
-HTML;
-
-
-/**
- * Additional toolbar elements
- */
-$toolbar = [];
-
-// check settings component and module existence
-if (\Yii::$app->has('settings') && \Yii::$app->hasModule('settings')) {
-
-    // check module permissions
-    $settingPermission = false;
-    if (\Yii::$app->getModule('settings')->accessRoles === null) {
-        $settingPermission = true;
-    } else {
-        foreach (\Yii::$app->getModule('settings')->accessRoles as $role) {
-            $settingPermission = \Yii::$app->user->can($role);
-        }
-    }
-
-    if ($settingPermission) {
-        $settings = [
-            'icon' => 'cogs',
-            'url' => ['/settings', 'SettingSearch' => ['section' => 'pages']],
-            'options' => [
-                'title' => Yii::t('pages', 'Settings'),
-                'class' => 'btn btn-info'
-            ]
-        ];
-        $toolbar[] = TreeView::BTN_SEPARATOR;
-        $toolbar['settings'] = $settings;
-    }
-}
-
-$mainTemplate = <<< HTML
-<div class="row">
-    <div class="col-md-5" id="dmstr-pages-detail-wrapper">
-        <div class="box box-solid">
-        {wrapper}
-        </div>
-    </div>
-    <div class="col-md-7" id="dmstr-pages-detail-panel">
-        {detail}
-    </div>
-</div>
-HTML;
-
-
-
-/**
- * Render tree view
- */
 echo TreeView::widget(
     [
         'query' => $queryTree,

--- a/views/default/index.php
+++ b/views/default/index.php
@@ -3,7 +3,7 @@
  * Output TreeView widget
  *
  * @var yii\web\View $this
- * @var \yii\db\ActiveQuery $queryTree
+ * @var \yii\db\ActiveQuery $query
  * @var string $headerTemplate
  * @var string $mainTemplate
  * @var array $toolbar
@@ -14,7 +14,7 @@ use yii\helpers\Inflector;
 
 echo TreeView::widget(
     [
-        'query' => $queryTree,
+        'query' => $query,
         'isAdmin' => true,
         'softDelete' => false,
         'displayValue' => 1,

--- a/views/default/index.php
+++ b/views/default/index.php
@@ -25,6 +25,9 @@ echo TreeView::widget(
         'treeOptions' => ['style' => 'height:auto; min-height:400px'],
         'headerTemplate' => $headerTemplate,
         'mainTemplate' => $mainTemplate,
-        'toolbar' => $toolbar
+        'toolbar' => $toolbar,
+        'krajeeDialogSettings' => [
+            'useNative' => true
+        ]
     ]
 );

--- a/views/treeview/_form.php
+++ b/views/treeview/_form.php
@@ -6,33 +6,51 @@ use dmstr\jsoneditor\JsonEditorWidget;
 use insolita\wgadminlte\Box;
 use kartik\form\ActiveForm;
 use kartik\select2\Select2;
+use kartik\tree\models\Tree;
 use kartik\tree\TreeView;
 use rmrevin\yii\fontawesome\FA;
 use Yii;
 use yii\helpers\Html;
 use yii\helpers\Json;
 use yii\helpers\Url;
+use yii\web\View;
 
 /**
- * @copyright Copyright &copy; Kartik Visweswaran, Krajee.com, 2014 - 2015
- * @package yii2-tree-manager
- * @version 1.5.0
- *
- * @var $this  \yii\web\View
- * @var $form \kartik\form\ActiveForm
- * @var $node \dmstr\modules\pages\models\Tree
- * @var $params array
- * @var $isAdmin boolean
- * @var $keyAttribute string
- * @var $action string
- * @var $currUrl string
- * @var $modelClass string
- * @var $softDelete boolean
- * @var $iconsList string
- * @var $nameAttribute string
- * @var $iconAttribute string
- * @var $iconTypeAttribute string
- * @var $showFormButtons boolean
+ * @var View $this
+ * @var Tree $node
+ * @var ActiveForm $form
+ * @var array $formOptions
+ * @var string $keyAttribute
+ * @var string $nameAttribute
+ * @var string $iconAttribute
+ * @var string $iconTypeAttribute
+ * @var array|string $iconsList
+ * @var string $formAction
+ * @var array $breadcrumbs
+ * @var array $nodeAddlViews
+ * @var mixed $currUrl
+ * @var boolean $isAdmin
+ * @var boolean $showIDAttribute
+ * @var boolean $showNameAttribute
+ * @var boolean $showFormButtons
+ * @var boolean $allowNewRoots
+ * @var string $nodeSelected
+ * @var string $nodeTitle
+ * @var string $nodeTitlePlural
+ * @var array $params
+ * @var string $keyField
+ * @var string $nodeView
+ * @var string $nodeAddlViews
+ * @var array $nodeViewButtonLabels
+ * @var string $noNodesMessage
+ * @var boolean $softDelete
+ * @var string $modelClass
+ * @var string $defaultBtnCss
+ * @var string $treeManageHash
+ * @var string $treeSaveHash
+ * @var string $treeRemoveHash
+ * @var string $treeMoveHash
+ * @var string $hideCssClass
  */
 
 $this->registerJs(
@@ -69,7 +87,7 @@ if (!$node->isNewRecord) {
  * Begin active form
  * @controller NodeController
  */
-$form = ActiveForm::begin(['action' => $action]);
+$form = ActiveForm::begin(['action' => $formAction, 'options' => $formOptions]);
 
 // Get tree manager module
 $treeViewModule = TreeView::module();
@@ -85,6 +103,9 @@ echo Html::hiddenInput('parentKey', $parentKey);
 echo Html::hiddenInput('currUrl', Url::to(['/pages', 'pageId' => $node->id]));
 echo Html::hiddenInput('modelClass', $modelClass);
 echo Html::hiddenInput('softDelete', $softDelete);
+echo Html::hiddenInput('treeManageHash', $treeManageHash);
+echo Html::hiddenInput('treeRemoveHash', $treeRemoveHash);
+echo Html::hiddenInput('treeMoveHash', $treeMoveHash);
 ?>
 
 


### PR DESCRIPTION
The issue was (as internally discussed) related to permission checking in hierarchical tree structures where children of restricted parent nodes were incorrectly being displayed to users without proper access rights. The existing permission system only checked individual node permissions but failed to enforce hierarchical access control, allowing users to see child nodes even when their parent nodes were restricted based on RBAC permissions.

The page tree shows only what users are allowed to see based on their permissions.

I also updated kartik-v/yii2-tree-manager (which was way more work than i expected as updating just a minor versions brings a low of bc in this package)

